### PR TITLE
Fix the extractZip() api bug.

### DIFF
--- a/src/server/fs/lib/fs-manager.js
+++ b/src/server/fs/lib/fs-manager.js
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2012-2015 S-Core Co., Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -933,6 +933,7 @@ function extractZip(absolutePath, target, rootPath, callback) {
             // -o options is overwrite.
             // -d options extract the specified directory.
             spawn('unzip', ['-oq', sourceRelativePath, '-d', targetRelativePath], {
+                stdio: [0, 1, 2], // use parent's stdio
                 cwd: rootPath
             }).on('close', function (code) {
                 if (code !== 0) {


### PR DESCRIPTION
When the stdio buffer of child process was full and parent process does not clear it, child process hang until the buffer is empty.
So, changed to use the parent's stdio.

Signed-off-by: Sangjin Kim <sangjin3.kim@samsung.com>