### PR TITLE
Add `replaceFiles` API and revert package.json file

### DIFF
--- a/src/server/fs/lib/fs-manager.js
+++ b/src/server/fs/lib/fs-manager.js
@@ -2372,7 +2372,7 @@ router.post('/webida/api/fs/replace/:fsid',
         var pattern = req.body.pattern;
         var replacePattern = req.body.replacePattern;
         var wholePattern;
-        var filePaths = req.body.where.split(',');
+        var filePaths = req.body.where.split(',').map(decodeURIComponent);
         var ignoreCase = req.body.ignorecase;
         var wholeWord = req.body.wholeword;
         var rootPath = (new WebidaFS(fsid)).getRootPath();

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -7,6 +7,7 @@
         "connect-domain": "*",
         "connect-multiparty": "1.2.5",
         "express-session": "1.9.1",
+        "http-proxy": "0.10.3",
         "http-master": "~1.0.18",
         "connect-mongo": "0.4.2",
         "session-file-store": "0.0.12",


### PR DESCRIPTION
- [FEATURE] add `replaceFiles` API to the file server
- [BUGFIX] revert `package.json` file
    - "http-proxy" package is still used in `app-manager` for serving nodejs app