### PR TITLE
[BUGFIX] (#117) fix 'Server Unreachable' error on Guest login

### DIFF
--- a/src/server/auth/lib/user-manager.js
+++ b/src/server/auth/lib/user-manager.js
@@ -1384,6 +1384,10 @@ router.post('/webida/api/oauth/guestlogin',
             },
             function (/*callback*/) {
                 logger.debug('attempt to login with user info ', user, req.session);
+                if (req.session) {
+                    // If returnTo(302 redirect url) is on the auth server, cross-origin problem will be occurred.
+                    req.session.returnTo = null;
+                }
                 loginHandler(req, res)(null, user);
             }
         ], function (err) {


### PR DESCRIPTION
- This is for prevent cross-origin (302 redirected from app server to auth server) issue.
- Once Guest login(requested from app server) is successfully ended, returnTo variable on the user session should be cleaned.

[REF log]

XMLHttpRequest cannot load https://auth.webida.net/webida/api/oauth/guestlogin. The request was redirected to 'https://auth.webida.net/webida/api/oauth/authorize?response_type=token&redi…&client_id=E9CXCte9dnUU1GID&skip_decision=false&type=web_server&state=site', which is disallowed for cross-origin requests that require preflight.