### PR TITLE
[BUGFIX] winston version fixing

### DIFF
--- a/src/server/package.json
+++ b/src/server/package.json
@@ -24,7 +24,7 @@
         "underscore": "1.5.2",
         "ncp": "0.4.2",
         "request": "*",
-        "winston": "*",
+        "winston": "~1.1.2",
         "querystring": "*",
         "passport": "~0.1.12",
         "express": "4.10.2",


### PR DESCRIPTION
[DESC.]
- winston v2.0 have a problem with webida-server

[REF log]

/home/webida/webida-server/webida.net/server/common/log-manager.js:65
            new (winston.transports.DailyRotateFile)({
            ^
TypeError: undefined is not a function
    at Object.<anonymous> (/home/webida/webida-server/webida.net/server/common/log-manager.js:65:13)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at svcType (/home/webida/webida-server/webida.net/server/unit-manager.js:78:14)
    at parseCommandLine (/home/webida/webida-server/webida.net/server/unit-manager.js:66:12)
    at Object.<anonymous> (/home/webida/webida-server/webida.net/server/unit-manager.js:70:1)
error: Forever detected script exited with code: 8