### PR TITLE
[BUGFIX] fix bug related with setting cookie

### DIFF
--- a/src/server/app/app.js
+++ b/src/server/app/app.js
@@ -67,7 +67,7 @@ function urlParser(req, res, next) {
 function webidaCookieSetter(req, res, next) {
     var conf = global.app.config;
     var appHostParsedUrl = require('url').parse(conf.appHostUrl);
-    var option = {domain: '.' + conf.domain};
+    var option = {domain: (conf.useReverseProxy ? '.' : '') + conf.domain};
     res.cookie('webida.host', appHostParsedUrl.host, option);
     res.cookie('webida.appHostUrl', conf.appHostUrl, option);
     res.cookie('webida.authHostUrl', conf.authHostUrl, option);

--- a/src/server/conf/default-conf.js
+++ b/src/server/conf/default-conf.js
@@ -119,6 +119,7 @@ var conf = {
     ],
 
     domain: domain,
+    useReverseProxy: useReverseProxy,
 
     internalAccessInfo: {
         fs: {


### PR DESCRIPTION
[DESC.]
- If the server is launched without `useReverseProxy` setting, the domain of the cookie shouldn't be started with '.'.