### PR TITLE
cleaning more logs 

### DIFF
--- a/src/server/common/auth-manager.js
+++ b/src/server/common/auth-manager.js
@@ -99,7 +99,7 @@ function _requestTokenInfo(token, callback) {
 
     req = http.request(options, function (res) {
         var data = '';
-        logger.info('res', res.statusCode);
+        logger.debug('result status code for token request :', res.statusCode);
         res.setEncoding('utf8');
         res.on('data', function (chunk) {
             data += chunk;
@@ -396,7 +396,7 @@ function assignPolicy(id, pid, token, callback) {
         path: template({pid: pid, user: id, token: token})
     };
     var req;
-    logger.info('assignPolicy', id, pid);
+    logger.info('assignPolicy', {id, pid});
 
     req = http.request(options, function (response) {
         var data = '';
@@ -515,7 +515,7 @@ function updatePolicyResource(oldPath, newPath, token, callback) {
         port: internalAccessInfo.auth.port,
         path: encodeURI(path)
     };
-    logger.info('updatePolicyResource', oldPath, newPath);
+    logger.info('updatePolicyResource', {oldPath, newPath});
 
     req = http.request(options, function (response) {
         var data = '';
@@ -552,7 +552,7 @@ function getFSInfo(fsid, token, callback) {
         port: internalAccessInfo.fs.port,
         path: path
     };
-    logger.info('getFSInfo', fsid, token, options);
+    logger.info('getFSInfo', {fsid, token, options});
 
     req = http.request(options, function (response) {
         var data = '';

--- a/src/server/common/http-logger.js
+++ b/src/server/common/http-logger.js
@@ -92,8 +92,7 @@ class AccessLogData {
         // headers[x] == name: value  (some names are duplicated) 
         // headers[-1] == "" (end of header!) 
         if (headers.length > 0) {
-            let firstLine = headers[0].split(' '); 
-            this.response.message = firstLine[2]; 
+            this.response.message = headers[0].slice(2).join(' ');
 	    }
         this.response.headers = {}; 
         for (let i=1; i < headers.length-1; i++) {
@@ -101,7 +100,7 @@ class AccessLogData {
             if (line.length < 2) {
                 continue; 
             }
-            let key = line[0].trim(); 
+            let key = line[0].trim();
             let value = line[1].trim();
             let current = this.response.headers[key];
             if (current) {

--- a/src/server/notify/lib/ntf.js
+++ b/src/server/notify/lib/ntf.js
@@ -284,7 +284,7 @@ var ChMgr = function () {
     this.getCh = function (name) {
         var tmp = self.chMap.get(name);
         if (!tmp) {
-            logger.error('can\'t find channel with id - ', name);
+            logger.debug('has no channel with id - ', name);
             return null;
         }
         return tmp;
@@ -295,7 +295,7 @@ var ChMgr = function () {
             var chid = cli.chlist[i];
             var ch = self.getCh(chid);
             if (!ch) {
-                logger.error('cannot find channel with ', chid);
+                logger.error('cannot find channel with id', chid);
             } else {
                 ch.unsub(cli);
             }


### PR DESCRIPTION
wtill working on #133 

 - lowered upload/download log of fs-manager to debug
  (data will be logged in access log, too)
 - fixed http-logger's logging message to respect whole HTTP message
 - lowered 'channel not found error' log level to debug, until it's not permanent.
 - lowered some auth-client info log to debug