### PR TITLE
fixed logging of *-install/uninstall scripts

### DIFF
--- a/src/server/common/logger-factory.js
+++ b/src/server/common/logger-factory.js
@@ -74,7 +74,7 @@ class WebidaLogger extends winston.Logger {
 
             delete options.level;
             /* jshint -W106 */
-            options.app_name = global.app.name;
+            options.app_name = (global.app ? global.app.name : process.argv[1]) || 'webida';
 
             let transport = parentLogger ?
                 new WebidaTransport(parentLogger._transport, options) :


### PR DESCRIPTION
 - will not crash anymore - syslog process name will be set to argv[1]
  if global.app is missing