### PR TITLE
[BUGFIX] Using no 'su' command with 'git.sh'

### DIFF
--- a/src/server/fs/bin/git.sh
+++ b/src/server/fs/bin/git.sh
@@ -4,7 +4,7 @@ SSH_KEY=$HOME/.userinfo/id_rsa
 TMP_SSH=`mktemp`
 
 if [ -f $SSH_KEY ]; then
-    echo "ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEY \$@" > $TMP_SSH
+    echo "export HOME=$HOME; ssh -q -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEY \$@" > $TMP_SSH
     chmod +x $TMP_SSH
     export GIT_SSH=$TMP_SSH
 fi

--- a/src/server/fs/lib/container/lxc.js
+++ b/src/server/fs/lib/container/lxc.js
@@ -127,7 +127,7 @@ Lxc.prototype.getOptions_ = function () {
 Lxc.prototype.execute = function (callback) {
     if(this.originalCmd && this.originalCmd === 'git.sh') {
         // Make an exception for execution of git.sh because of its unstable action in LXC
-        this.proc = childProc.spawn('sudo', ['su', config.userid, '-c', this.getCmdStr_()], {
+        this.proc = childProc.spawn('git.sh', this.args, {
             cwd: path.join(this.wfs.getRootPath(), this.options.cwd),
             env: this.getOptions_().env
         });

--- a/src/system-configs/sudoers
+++ b/src/system-configs/sudoers
@@ -1,4 +1,4 @@
 # Allow webida to handle webida service
 # add this file to /etc/sudoers.d
 
-webida ALL = (root) NOPASSWD: /usr/bin/lxc-execute, /sbin/btrfs, /usr/sbin/xfs_quota, /usr/bin/rsync, /bin/kill, /usr/bin/lxc-stop, /bin/su webida -c git.sh *
+webida ALL = (root) NOPASSWD: /usr/bin/lxc-execute, /sbin/btrfs, /usr/sbin/xfs_quota, /usr/bin/rsync, /bin/kill, /usr/bin/lxc-stop


### PR DESCRIPTION
- With `su` command, $HOME env variable reset.
- Let `git.sh` be executed without `sudo su` command. (It'd had problem until I added `export HOME=$HOME;` in this `git.sh` file.