### PR TITLE
[TASK] added default app routing

### DIFF
--- a/src/server/app/lib/app-manager.js
+++ b/src/server/app/lib/app-manager.js
@@ -1747,8 +1747,20 @@ router.get('/webida/api/app/configs',
     }
 );
 
+
+function _handleDefaultApp(req, res, next) {
+   App.getInstanceByAppid( config.defaultAppId, (err, app) => {
+      if (err) {
+         return res.sendErrorPage(404, 'cannot find default app ' + config.defaultAppId ); 
+      }
+      let redirectTo = app.getBaseUrl() + '/index.html'; 
+      res.redirect(redirectTo); 
+   }); 
+} 
+
+router.get('/', _handleDefaultApp); 
+router.get('/index.html', _handleDefaultApp); 
+
 router.all('*', frontend, function (req, res) {
     res.status(500).send('Unknown page');
 });
-
-

--- a/src/server/conf/default-conf.js
+++ b/src/server/conf/default-conf.js
@@ -154,13 +154,14 @@ var conf = {
             oAuthClientId: 'DASHBOARD_CLIENT_ID',
             oAuthClientSecret: 'DASHBOARD_CLIENT_SECRET',
             redirectUrl: '/pages/auth.html',
-            domain: '',
+            domain: 'dashboard',
             appType: 'html',
             name: 'Webida Dashboard',
             desc: 'Webida client application that manages workspaces & user profiles',
             status: 'running'
         }
     ],
+    defaultAppId: 'app-dashbaord',
 
     internalAccessInfo: {
         fs: {

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webida-server",
-    "version": "1.6.2",
+    "version": "1.7.0",
     "main": "./unit-manager.js",
     "repository": {
         "type": "git",


### PR DESCRIPTION
 - changed dashboard app domain to 'dashboard', not empty
 - added default app routing logic for dashboard
 - bumped server version to 1.7

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/webida/webida-server/202)
<!-- Reviewable:end -->
