### PR TITLE
[BUGFIX] defaultAppId should be applied to 'path' type only

### DIFF
--- a/src/server/app/lib/app-manager.js
+++ b/src/server/app/lib/app-manager.js
@@ -1747,19 +1747,19 @@ router.get('/webida/api/app/configs',
     }
 );
 
-
-function _handleDefaultApp(req, res, next) {
-   App.getInstanceByAppid( config.defaultAppId, (err, app) => {
-      if (err) {
-         return res.sendErrorPage(404, 'cannot find default app ' + config.defaultAppId ); 
-      }
-      let redirectTo = app.getBaseUrl() + '/index.html'; 
-      res.redirect(redirectTo); 
-   }); 
-} 
-
-router.get('/', _handleDefaultApp); 
-router.get('/index.html', _handleDefaultApp); 
+if (config.services.app.deploy.type ==='path') {
+    let _handleDefaultApp = function (req, res) {
+        App.getInstanceByAppid( config.defaultAppId, (err, app) => {
+            if (err) {
+                return res.sendErrorPage(404, 'cannot find default app ' + config.defaultAppId );
+            }
+            let redirectTo = app.getBaseUrl() + '/index.html';
+            res.redirect(redirectTo);
+        });
+    };
+    router.get('/', _handleDefaultApp);
+    router.get('/index.html', _handleDefaultApp);
+}
 
 router.all('*', frontend, function (req, res) {
     res.status(500).send('Unknown page');


### PR DESCRIPTION
- temporal work-around for webida.net
- when app server deploys apps in domain mode,
  accessing '/'without domain should not be redirected to '/' again

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webida/webida-server/206)

<!-- Reviewable:end -->
